### PR TITLE
Restore clear screen on shutdown feature

### DIFF
--- a/stage3/07-patches/files/pwnagotchi.service
+++ b/stage3/07-patches/files/pwnagotchi.service
@@ -8,6 +8,7 @@ After=pwngrid-peer.service
 Type=simple
 WorkingDirectory=~
 ExecStart=/usr/bin/pwnagotchi-launcher
+ExecStopPost=bash -c "if egrep -iq 'clearonshutdown.*=.*true' /etc/pwnagotchi/config.toml; then pwnagotchi --clear; fi"
 Restart=always
 RestartSec=30
 TasksMax=infinity


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Changes the pwnagotchi service to optionally clear the screen when pwnagotchi exits

## Description
<!--- Describe your changes in detail -->

greps for "clearonshutdown=true" in config.toml, and if so clears the screen

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Some people wanted the screen to clear when they exit pwnagotchi

<!--- If it fixes an open issue, please link to the issue here. -->
- [ X ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on 2.9.5-3. Restarted pwnagotchi multiple times, changing the value in config.toml.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

bug fix because it used to exist but went away.  new feature, since it went away and this adds it back

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X ] I have signed-off my commits with `git commit -s`
